### PR TITLE
Wip kyle polygon api wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 .csv/
 /.csv
 storage/
+data-pipeline/test.py

--- a/data-pipeline/scrape_twitter.py
+++ b/data-pipeline/scrape_twitter.py
@@ -7,7 +7,7 @@ class Twitter:
         c.Search= search
         c.Lang="en"
         c.Pandas= True
-        c.Limit= 100
+        c.Limit= 30
         c.Popular_tweets = True
         c.Hide_output = True
         c.Min_likes = 100
@@ -18,6 +18,6 @@ class Twitter:
             return twint.output.panda.Tweets_df[columns]
         
         data= twint_to_pd(["id","created_at","username","tweet","cashtags"])
-        data["tweet"]= data["tweet"].str.replace("[^a-zA-Z0-9]", " ")
+        #data["tweet"]= data["tweet"].str.replace("[^a-zA-Z0-9]", " ")
         
         return(data)

--- a/data-pipeline/scrape_twitter.py
+++ b/data-pipeline/scrape_twitter.py
@@ -1,31 +1,23 @@
-# Import unofficial twitter API
 import twint
+import pandas as pd
 
-class twitter_scrape:
-    # def __init__(self, config):
-    #     self.config = config
-    
-    def config(ticker):
-        config = twint.Config()
-        config.Custom["tweet"] = ["id","created_at","username","tweet","cashtags"]
-        config.Store_json = True
-        config.Store_object = True
-        config.Min_likes = 1000
-        config.Search = ticker
-        config.Output = "./"+ticker + ".json"
-        config.Popular_tweets = True
-        config.Lang = "en"
+class Twitter:
+    def scrape(search):
+        c= twint.Config()
+        c.Search= search
+        c.Lang="en"
+        c.Pandas= True
+        c.Limit= 100
+        c.Popular_tweets = True
+        c.Hide_output = True
+        c.Min_likes = 100
 
-        #Display output to command line bool.
-        config.Hide_output = False
-        return config
+        twint.run.Search(c)
 
-    def run_scrape(self, search):
-        twint.run.Search(twitter_scrape.config(search))
-
-def main():
-    scrape = twitter_scrape()
-    scrape.run_scrape(input('Search: '))
-
-main() 
-
+        def twint_to_pd(columns):
+            return twint.output.panda.Tweets_df[columns]
+        
+        data= twint_to_pd(["id","created_at","username","tweet","cashtags"])
+        data["tweet"]= data["tweet"].str.replace("[^a-zA-Z0-9]", " ")
+        
+        return(data)

--- a/data-pipeline/stock_data_api.py
+++ b/data-pipeline/stock_data_api.py
@@ -1,13 +1,53 @@
 #Stock API file
 import requests as requests
+import statistics
 
-ticker = 'APPL'
+ticker = 'AAPL'
+date_from = '2022-05-01'
+date_to = '2022-05-20'
+timespan = 'day'
 
 class StockAPI:
-    def getStock(ticker):
-        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/day/2022-06-30/2022-06-30?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
+    def getStock(ticker, timespan, date_from, date_to):
+        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
+        result = result.json()
+        allpoints = result['results']
+        print('\nSTOCK: '+ticker+'\nFROM: '+date_from+'\nTO: '+date_to+'\nTIMESCALE: '+timespan+'\n')
+        return allpoints
+        
+    def getStockAvg(ticker, timespan, date_from, date_to):
+        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
         result = result.json()
         
-        return result
+        close = []
+        high = []
+        low = []
+        transactions = []
+        open = []
+        volume = []
+        vw_price = []
 
-    print(getStock(ticker))
+        for day in result['results']:
+            close.append(day['c'])
+            high.append(day['h'])
+            low.append(day['l'])
+            transactions.append(day['n'])
+            open.append(day['o'])
+            volume.append(day['v'])
+            vw_price.append(day['vw'])
+        
+        averages = {
+            "Avg_Close": round(statistics.mean(close),2),
+            "Avg_High": round(statistics.mean(high),2),
+            "Avg_Low": round(statistics.mean(low),2),
+            "Avg_Transaction_n": round(statistics.mean(transactions),2),
+            "Avg_Open": round(statistics.mean(open),2),
+            "Avg_Volume": round(statistics.mean(volume),2),
+            "Avg_vwAVG": round(statistics.mean(vw_price),2),
+
+        }
+
+        return averages
+
+    print(getStockAvg(ticker, timespan, date_from, date_to))
+

--- a/data-pipeline/stock_data_api.py
+++ b/data-pipeline/stock_data_api.py
@@ -2,23 +2,31 @@
 import requests as requests
 import statistics
 
-ticker = 'AAPL'
-date_from = '2022-05-01'
-date_to = '2022-05-20'
+
+#Testing variables, remove in production 
+########################################
+ticker = 'AMZN'
 timespan = 'day'
+date_from = '2022-01-01'
+date_to = '2022-05-20'
+########################################
+
 
 class StockAPI:
+    #Returns all candles within date_from -> date_to on a scale of the timespan variable
     def getStock(ticker, timespan, date_from, date_to):
-        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
+        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=50000&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
         result = result.json()
         allpoints = result['results']
         print('\nSTOCK: '+ticker+'\nFROM: '+date_from+'\nTO: '+date_to+'\nTIMESCALE: '+timespan+'\n')
         return allpoints
-        
+
+    #Retuns the average of all candles within date_from -> date_to on scale of timespan variable 
     def getStockAvg(ticker, timespan, date_from, date_to):
-        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
+        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/'+timespan+'/'+date_from+'/'+date_to+'?adjusted=true&sort=asc&limit=50000&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
         result = result.json()
         
+        #Initalise lists for all data
         close = []
         high = []
         low = []
@@ -27,6 +35,7 @@ class StockAPI:
         volume = []
         vw_price = []
 
+        #Every result that is gathered from the API is broken up and added to it's respective list
         for day in result['results']:
             close.append(day['c'])
             high.append(day['h'])
@@ -36,6 +45,7 @@ class StockAPI:
             volume.append(day['v'])
             vw_price.append(day['vw'])
         
+        #Vatiable that calculates all averages using statistics library
         averages = {
             "Avg_Close": round(statistics.mean(close),2),
             "Avg_High": round(statistics.mean(high),2),
@@ -44,10 +54,14 @@ class StockAPI:
             "Avg_Open": round(statistics.mean(open),2),
             "Avg_Volume": round(statistics.mean(volume),2),
             "Avg_vwAVG": round(statistics.mean(vw_price),2),
-
+            "Days_Results": len(close),
+            "Date_Start": date_from,
+            "Date_End": date_to
         }
 
         return averages
 
+    #Testing statement, remove in production
+    ########################################
     print(getStockAvg(ticker, timespan, date_from, date_to))
-
+    ########################################

--- a/data-pipeline/stock_data_api.py
+++ b/data-pipeline/stock_data_api.py
@@ -1,1 +1,13 @@
 #Stock API file
+import requests as requests
+
+ticker = 'APPL'
+
+class StockAPI:
+    def getStock(ticker):
+        result = requests.get('https://api.polygon.io/v2/aggs/ticker/'+ticker+'/range/1/day/2022-06-30/2022-06-30?adjusted=true&sort=asc&limit=120&apiKey=cIuSO8Ppb4LRsbWqirmxhU8ejDXNFVMW')
+        result = result.json()
+        
+        return result
+
+    print(getStock(ticker))

--- a/data-pipeline/stock_data_api.py
+++ b/data-pipeline/stock_data_api.py
@@ -5,10 +5,10 @@ import statistics
 
 #Testing variables, remove in production 
 ########################################
-ticker = 'AMZN'
-timespan = 'day'
-date_from = '2022-01-01'
-date_to = '2022-05-20'
+#ticker = 'AMZN'
+#timespan = 'day'
+#date_from = '2022-01-01'
+#date_to = '2022-05-20'
 ########################################
 
 
@@ -63,5 +63,5 @@ class StockAPI:
 
     #Testing statement, remove in production
     ########################################
-    print(getStockAvg(ticker, timespan, date_from, date_to))
+    #print(getStockAvg(ticker, timespan, date_from, date_to))
     ########################################


### PR DESCRIPTION
Have added a class that acts as a wrapper for the polygon.io REST API.  At the moment functions can either return all candles between 2 dates (Limited to 2 years in the past, because free plan) or it can return the averages of the datapoints in a specified time period. Closing #41 